### PR TITLE
Add UML sequence diagram generation file

### DIFF
--- a/uml-sequence-diagram.puml
+++ b/uml-sequence-diagram.puml
@@ -1,0 +1,87 @@
+@startuml
+Actor main
+activate motor
+activate chamber
+activate grain
+activate combustion
+activate state
+activate gas
+main -> motor: d_dt
+motor -> chamber: generate
+chamber -> chamber: burn_rate
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: surface_area
+grain --> chamber
+chamber -> combustion: rho_solid
+combustion --> chamber
+chamber -> combustion: T_flame
+combustion --> chamber
+chamber -> gas: c_p
+gas --> chamber
+activate generation_rate
+chamber -> generation_rate: <<construct>>
+generation_rate --> chamber
+chamber --> motor
+motor -> chamber: outflow
+chamber -> state: energy
+state --> chamber
+chamber -> state: mass
+state --> chamber
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: volume
+gas --> chamber
+chamber -> gas: c_p
+gas --> chamber
+chamber -> gas: T
+gas --> chamber
+chamber -> gas: p
+gas --> chamber
+chamber -> nozzle: area
+nozzle --> chamber
+chamber -> gas: g
+gas --> chamber
+chamber -> gas: R_gas
+gas --> chamber
+activate flow_rate
+chamber -> flow_rate: <<construct>>
+flow_rate --> chamber
+chamber --> motor
+motor -> generation_rate: m_dot_gen
+generation_rate --> motor
+motor -> flow_rate: m_dot_out
+flow_rate --> motor
+motor -> generation_rate: e_dot_gen
+generation_rate --> motor
+motor -> flow_rate: e_dot_out
+flow_rate --> motor
+motor -> chamber: burn_rate
+
+chamber -> state: energy
+state --> chamber
+chamber -> state: mass
+state --> chamber
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: volume
+grain --> chamber
+chamber -> gas: p
+gas --> chamber
+chamber -> combustion: burn_rate
+combustion --> chamber
+chamber --> motor
+motor --> main
+
+activate rate
+motor --> rate: <<construct>>
+rate --> motor
+motor -> main
+main -> rate: operator(  *  )
+rate --> main
+main -> state: operator(  +  )
+state --> main
+main -> state: <<result>>
+state --> main
+
+@enduml


### PR DESCRIPTION
@Brian I installed Atom's [plantuml-toolkit] package, which can be used to generate UML sequence diagrams and view them inside Atom.  PlantUML processes the new file `uml-sequence-diagram.puml` and  generates a nice graphical depiction of the object interactions involved in the main program's `state = state + motor%d_dt(state)*dt` statement.  I'll show it all to you the next time we talk.  This pull request adds the `uml-sequence-diagram.puml` diagram generator.

[plantuml-toolkit]: https://atom.io/packages/plantuml-toolkit