### PR TITLE
Reorganize & expand documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@
 *.app
 
 # Subdirectories
-doc
 build
 
 # Visual Studio

--- a/doc/api.puml
+++ b/doc/api.puml
@@ -1,0 +1,22 @@
+@startuml
+Title Rocket API: Classes Employed in the Main Program
+class motor_t {
+  define( input_file : character(len=*))
+  chamber() : chamber_t
+  dt() : real
+  t_max() : real
+  d_dt(persistent_state_t) : state_rate_t
+}
+
+motor_t -right- state_rate_t : produces >
+motor_t -down- persistent_state_t  : differentiates >
+
+class state_rate_t {
+  operator(*)(state_rate_t, real) : persistent_state_t
+}
+
+class persistent_state_t {
+  define(input_file : character(len=*))
+  operator(+)(persistent_state_t, persistent_state_t) : persistent_state_t
+}
+@enduml

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1,10 +1,10 @@
 project: Rocket
 summary: A mini-app demonstrating the emulation of a functional, object-oriented style for
          calculating aggregate tablet burn in inflator chambers using (mostly) Fortran 90.
-src_dir: src/rocket
-exclude_dir: src/utilities
-exclude_dir: src/original
-output_dir: doc
+src_dir: ../src/rocket
+exclude_dir: ../src/utilities
+exclude_dir: ../src/original
+output_dir: ford-docs
 display: public
          protected
          private
@@ -44,5 +44,3 @@ are pure functions.
 
 [This document is a FORD project file, formatted with Pythonic Markdown                                      ]:#
 [See https://github.com/Fortran-FOSS-programmers/ford/wiki/Project-File-Options for more info on writing FORD project files]:#
-
-

--- a/doc/uml-class-diagram.puml
+++ b/doc/uml-class-diagram.puml
@@ -1,0 +1,24 @@
+@startuml
+Title Objects Supporting the Rocket Main Program
+
+  object motor
+  object numerics
+  object chamber
+  object grain
+  object gas
+  object combustion
+  object nozzle
+  object state
+  object state_rate_t
+
+  motor -left- state : differentiates >
+  motor -right- state_rate_t : produces >
+  motor *-- numerics
+  motor *-- chamber
+
+  chamber *-- grain
+  chamber *-- gas
+  chamber *-- combustion
+  chamber *-- nozzle
+
+@enduml

--- a/doc/uml-sequence-diagram.puml
+++ b/doc/uml-sequence-diagram.puml
@@ -1,0 +1,91 @@
+@startuml
+Title UML Sequence Diagram for evaluating "state + motor%d_dt(state)*dt"
+Actor main
+activate motor
+activate chamber
+activate grain
+activate gas
+activate combustion
+activate nozzle
+activate state
+main -> motor: d_dt
+motor -> chamber: generate
+chamber -> chamber: burn_rate
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: surface_area
+grain --> chamber
+chamber -> combustion: rho_solid
+combustion --> chamber
+chamber -> combustion: T_flame
+combustion --> chamber
+chamber -> gas: c_p
+gas --> chamber
+
+activate generation_rate
+chamber -> generation_rate: <<construct>>
+generation_rate --> chamber
+chamber --> motor
+motor -> chamber: outflow
+chamber -> state: energy
+state --> chamber
+chamber -> state: mass
+state --> chamber
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: volume
+gas --> chamber
+chamber -> gas: c_p
+gas --> chamber
+chamber -> gas: T
+gas --> chamber
+chamber -> gas: p
+gas --> chamber
+chamber -> nozzle: area
+nozzle --> chamber
+chamber -> gas: g
+gas --> chamber
+chamber -> gas: R_gas
+gas --> chamber
+
+activate flow_rate
+chamber -> flow_rate: <<construct>>
+flow_rate --> chamber
+chamber --> motor
+motor -> generation_rate: m_dot_gen
+generation_rate --> motor
+motor -> flow_rate: m_dot_out
+flow_rate --> motor
+motor -> generation_rate: e_dot_gen
+generation_rate --> motor
+motor -> flow_rate: e_dot_out
+flow_rate --> motor
+motor -> chamber: burn_rate
+chamber -> state: energy
+state --> chamber
+chamber -> state: mass
+state --> chamber
+chamber -> state: burn_depth
+state --> chamber
+chamber -> grain: volume
+grain --> chamber
+chamber -> gas: p
+gas --> chamber
+chamber -> combustion: burn_rate
+combustion --> chamber
+chamber --> motor
+
+activate rate
+motor -> rate: <<construct>>
+rate --> motor
+deactivate generation_rate
+deactivate flow_rate
+motor -> main
+main -> rate: operator (  *  )
+rate --> main
+deactivate rate
+
+main -> state: operator (  +  )
+state --> main
+
+@enduml

--- a/uml-sequence-diagram.puml
+++ b/uml-sequence-diagram.puml
@@ -1,11 +1,13 @@
 @startuml
+Title UML Sequence Diagram for evaluating "state + motor%d_dt(state)*dt"
 Actor main
 activate motor
 activate chamber
 activate grain
-activate combustion
-activate state
 activate gas
+activate combustion
+activate nozzle
+activate state
 main -> motor: d_dt
 motor -> chamber: generate
 chamber -> chamber: burn_rate
@@ -19,6 +21,7 @@ chamber -> combustion: T_flame
 combustion --> chamber
 chamber -> gas: c_p
 gas --> chamber
+
 activate generation_rate
 chamber -> generation_rate: <<construct>>
 generation_rate --> chamber
@@ -44,6 +47,7 @@ chamber -> gas: g
 gas --> chamber
 chamber -> gas: R_gas
 gas --> chamber
+
 activate flow_rate
 chamber -> flow_rate: <<construct>>
 flow_rate --> chamber
@@ -57,7 +61,6 @@ generation_rate --> motor
 motor -> flow_rate: e_dot_out
 flow_rate --> motor
 motor -> chamber: burn_rate
-
 chamber -> state: energy
 state --> chamber
 chamber -> state: mass
@@ -71,17 +74,18 @@ gas --> chamber
 chamber -> combustion: burn_rate
 combustion --> chamber
 chamber --> motor
-motor --> main
 
 activate rate
-motor --> rate: <<construct>>
+motor -> rate: <<construct>>
 rate --> motor
+deactivate generation_rate
+deactivate flow_rate
 motor -> main
-main -> rate: operator(  *  )
+main -> rate: operator (  *  )
 rate --> main
-main -> state: operator(  +  )
-state --> main
-main -> state: <<result>>
+deactivate rate
+
+main -> state: operator (  +  )
 state --> main
 
 @enduml


### PR DESCRIPTION
  Add PlantUML files for generating

    1. High-level API class diagram.
    2. Main program object diagram.
    
Move PlatUML and FORD documentation files to top-level doc subdirectory.  
Remove "doc" from .gitignore.