### PR TITLE
Refine the UML diagrams in the doc subdirectory

### DIFF
--- a/doc/api.puml
+++ b/doc/api.puml
@@ -1,5 +1,5 @@
 @startuml
-Title Rocket API: Classes Employed in the Main Program
+Title Rocket API: Classes Explicitly Referenced in the Main Program
 class motor_t {
   define( input_file : character(len=*))
   chamber() : chamber_t
@@ -8,12 +8,7 @@ class motor_t {
   d_dt(persistent_state_t) : state_rate_t
 }
 
-motor_t -right- state_rate_t : produces >
 motor_t -down- persistent_state_t  : differentiates >
-
-class state_rate_t {
-  operator(*)(state_rate_t, real) : persistent_state_t
-}
 
 class persistent_state_t {
   define(input_file : character(len=*))

--- a/doc/uml-object-diagram.puml
+++ b/doc/uml-object-diagram.puml
@@ -9,10 +9,12 @@ Title Objects Supporting the Rocket Main Program
   object combustion
   object nozzle
   object state
+  object state_t
   object state_rate_t
 
   motor -left- state : differentiates >
-  motor -right- state_rate_t : produces >
+  motor -right-> state_rate_t : produces 
+  state_rate_t -> state_t : produces
   motor *-- numerics
   motor *-- chamber
 

--- a/doc/uml-sequence-diagram.puml
+++ b/doc/uml-sequence-diagram.puml
@@ -15,8 +15,8 @@ chamber -> state: burn_depth
 state --> chamber
 chamber -> grain: surface_area
 grain --> chamber
-chamber -> combustion: rho_solid
-combustion --> chamber
+chamber -> grain: rho_solid
+grain --> chamber
 chamber -> combustion: T_flame
 combustion --> chamber
 chamber -> gas: c_p
@@ -75,15 +75,19 @@ chamber -> combustion: burn_rate
 combustion --> chamber
 chamber --> motor
 
-activate rate
-motor -> rate: <<construct>>
-rate --> motor
+activate state_rate_t
+motor -> state_rate_t: <<construct>>
+state_rate_t --> motor
 deactivate generation_rate
 deactivate flow_rate
-motor -> main
-main -> rate: operator (  *  )
-rate --> main
-deactivate rate
+motor --> main
+main -> state_rate_t: operator (  *  )
+state_rate_t -> persistent_state_t: <<construct>
+activate persistent_state_t
+persistent_state_t --> state_rate_t
+state_rate_t --> main
+deactivate persistent_state_t
+deactivate state_rate_t
 
 main -> state: operator (  +  )
 state --> main


### PR DESCRIPTION
1. Update the API description to show class diagrams only for the two classes explicitly declared in `main.f90`.
2. Update the object diagram to include the anonymous `state_t` object produced by the `state_rate_t` generic `operator(*)` binding.
3. Update the sequence diagram to show the construction of the `state_t` object produced  by the `state_rate_t` generic `operator(*)` binding and fix a few other details.