### PR TITLE
Match burnout

### DIFF
--- a/src/rocket/modules/chamber_module.f90
+++ b/src/rocket/modules/chamber_module.f90
@@ -86,8 +86,11 @@ contains
     type(state_t), intent(in) :: state
     real(rkind) burn_rate
 
-    associate(e => state%energy(), m => state%mass(), V => this%grain_%volume(state%burn_depth()))
-      burn_rate = this%combustion_%burn_rate(this%gas_%p(energy=e, mass=m, volume=V))
+    associate(burn_depth=>state%burn_depth())
+      associate(e => state%energy(), m => state%mass(), V => this%grain_%volume(burn_depth))
+        burn_rate = &
+          merge(0._rkind, this%combustion_%burn_rate(this%gas_%p(energy=e, mass=m, volume=V)), this%grain_%burned_out(burn_depth))
+      end associate
     end associate
   end function
 

--- a/src/rocket/modules/grain_module.f90
+++ b/src/rocket/modules/grain_module.f90
@@ -16,6 +16,7 @@ module grain_module
     procedure :: surface_area
     procedure :: volume
     procedure :: rho_solid
+    procedure :: burned_out
   end type
 
 contains
@@ -44,6 +45,23 @@ contains
     this%rho_solid_ = rho_solid_
   end subroutine
 
+  pure function burned_out(this, burn_depth)
+    class(grain_t), intent(in) :: this
+    real(rkind), intent(in) :: burn_depth
+    logical burned_out
+    integer, parameter :: ends = 2
+
+    associate(lost_length => ends*burn_depth)
+      associate( &
+        grain_length => this%length_ - lost_length, &
+        id => this%id_+ lost_length, &
+        od => (this%od_) &
+      )
+        burned_out = id>od .or. grain_length<0
+      end associate
+    end associate
+  end function
+
   pure function rho_solid(this)
     class(grain_t), INTENT(IN) :: this
     real(rkind) rho_solid
@@ -56,7 +74,7 @@ contains
     real(rkind), intent(in) :: burn_depth
     real(rkind) surface_area
     integer, parameter :: ends = 2
-    real(rkind), parameter :: four=4._rkind
+    real(rkind), parameter :: four=4, zero=0
 
     associate(lost_length => ends*burn_depth)
       associate( &
@@ -64,7 +82,7 @@ contains
         id => this%id_+ lost_length, &
         od => (this%od_) &
       )
-        surface_area = merge(0._rkind, pi*(id*grain_length + ends*(od**2-id**2)/four), id>od .or. grain_length<0._rkind)
+        surface_area = merge(zero, pi*(id*grain_length + ends*(od**2-id**2)/four), this%burned_out(burn_depth))
       end associate
     end associate
   end function

--- a/src/rocket/reference/legacy_rocket.f90
+++ b/src/rocket/reference/legacy_rocket.f90
@@ -233,13 +233,11 @@ close(file_unit)
   do i=1,nsteps
    call burnrate
    call calcsurf
-
-   call calmdotgen
-   call massflow
-  ! [mdot,engy,dsign]= massflow(p1,pamb,t1,tamb,cp,cp,rgas,rgas,g,g,area)
+   call calmdotgen  ! [mdot,engy,dsign]= massflow(p1,pamb,t1,tamb,cp,cp,rgas,rgas,g,g,area)
    call addmass
    call calct
    call calcp
+   call massflow
    call calcthrust
    time=time+dt
    output(i,:)=[time,p,t,mdotos,thrust,vol]


### PR DESCRIPTION
The OO code results now match the legacy code results except that the temperature flatlines after the chamber pressure equilibrates with the ambient pressure.  This happens because the temperature is calculated as `T = e/(c_v*mass)` and the mass remains constant once there is no pressure to drive the flow.