### PR TITLE
fix initial condition mismatch

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -18,7 +18,9 @@ program main
   call motor%define(input_file)
 
   associate(chamber => motor%chamber())
-    call state%define(input_file, gas=chamber%gas(), volume=chamber%initial_volume(), time=zero, burn_depth=zero)
+    associate(gas => chamber%gas())
+      call state%define(input_file, R_gas=gas%R_gas(), c_v=gas%c_v(), volume=chamber%initial_volume(), time=zero, burn_depth=zero)
+    end associate
   end associate
 
   associate(dt => motor%dt() )

--- a/src/rocket/state_implementation.f90
+++ b/src/rocket/state_implementation.f90
@@ -5,7 +5,6 @@ submodule(state_interface) state_implementation
 contains
 
   module procedure define
-    use gas_interface, only : gas_t
     use assertions_interface, only : assert, max_errmsg_len
     real(rkind) :: temperature_, pressure_
     namelist/state_list/ temperature_, pressure_
@@ -25,10 +24,8 @@ contains
     end block
 
     associate(V => (volume), T => (temperature_), p => (pressure_))
-      associate(R_gas => gas%R_gas(), c_v => gas%c_v())
-        this%mass_ = p*V/(R_gas*T)
-        this%energy_ = this%mass_*c_v*T
-      end associate
+      this%mass_ = p*V/(R_gas*T)
+      this%energy_ = this%mass_*c_v*T
     end associate
   end procedure
 

--- a/src/rocket/state_interface.f90
+++ b/src/rocket/state_interface.f90
@@ -22,14 +22,12 @@ module state_interface
 
   interface
 
-    module subroutine define(this, input_file, gas, volume, time, burn_depth)
+    module subroutine define(this, input_file, R_gas, c_v, volume, time, burn_depth)
       !! set all components of this gas_t object
-      use gas_interface, only : gas_t
       implicit none
       class(state_t), intent(out) :: this
       character(len=*), intent(in) :: input_file
-      type(gas_t), intent(in) :: gas
-      real(rkind), intent(in) :: volume, time, burn_depth
+      real(rkind), intent(in) :: R_gas, c_v, volume, time, burn_depth
     end subroutine
 
     pure module function new_state(mass, energy, burn_depth, time)


### PR DESCRIPTION
All output variables now match perfectly at the outset and to within approximately 0.05% at the final state.

By eliminating the `state_t` dependence on `gas_t`, this PR also makes the code consistent with the principle that is commonly an aim of object-oriented design patterns: making code highly cohesive yet loosely coupled. 