### PR TITLE
Verify results

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -60,8 +60,8 @@ contains
 
     interface
      function legacy_rocket(input_file)
-       use results_interface, only : results_t
-        implicit none
+       import results_t
+       implicit none
        character(len=*), intent(in) :: input_file
        type(results_t) legacy_rocket
      end function

--- a/src/main.f90
+++ b/src/main.f90
@@ -1,7 +1,7 @@
 program main
   !! A mini-application for rocket motor simulation:
   !! demonstrating an object-oriented, functional programming style in Fortran 2018
-  !! with automatic graphinf of results in gnuplot for comparison against a legacy,
+  !! with automatic graphing of results in gnuplot for comparison against a legacy,
   !! procedural simulator written in Fortran 90.
   use motor_interface, only : motor_t
   use state_interface, only : state_t
@@ -32,47 +32,54 @@ program main
   end associate
 
   call write_histories
-  call graph_results_if_requested
+  call graph_if_requested
 
   print *,"Test passed."
 
 contains
 
-  subroutine graph_results_if_requested
+  subroutine write_history(results, file_name)
+    use assertions_interface, only : assert, max_errmsg_len
+    use results_interface, only : results_t
+    type(results_t), intent(in) :: results
+    character(len=*), intent(in) :: file_name
+    character(len=max_errmsg_len) error_message
+    integer io_status, file_unit
+    integer, parameter :: success = 0
+
+    open(newunit=file_unit, file=file_name, status="unknown", iostat=io_status, iomsg=error_message)
+    call assert(io_status == success, "main (opening "//file_name//"): io_status == success", diagnostic_data=error_message)
+    write(unit=file_unit, fmt=*) results
+    close(file_unit)
+  end subroutine
+
+  subroutine write_histories
+    use results_interface, only : results_t
+    character(len=*), parameter :: header(*) = &
+        [character(len=len("temperature")) :: "time", "pressure", "temperature", "mdotos", "thrust", "volume"]
+
+    interface
+     function legacy_rocket(input_file)
+       use results_interface, only : results_t
+        implicit none
+       character(len=*), intent(in) :: input_file
+       type(results_t) legacy_rocket
+     end function
+   end interface
+
+    associate(modern_results => results_t(header, motor%derived_variables(history)))
+      associate(legacy_results => legacy_rocket(input_file))
+        call write_history(modern_results, "rocket.out")
+        call write_history(legacy_results, "legacy_rocket.out")
+      end associate
+    end associate
+  end subroutine
+
+  subroutine graph_if_requested()
     use command_line_interface, only : command_line_t
     type(command_line_t) command
     character(len=*), parameter :: graph(*) = [character(len=len("--graph")):: "--graph", "-g", "/graph", "/g"]
 
     if (command%argument_present(graph)) call execute_command_line('gnuplot gnuplot.inp')
   end subroutine
-
-  subroutine write_histories
-    use assertions_interface, only : assert, max_errmsg_len
-    use results_interface, only : results_t
-    character(len=*), parameter :: header(*) = &
-       [ character(len=len("temperature")) :: "time", "pressure", "temperature", "mdotos", "thrust", "volume"]
-    character(len=max_errmsg_len) error_message
-    integer io_status, file_unit
-    integer, parameter :: success = 0
-
-    interface
-      function legacy_rocket(input_file)
-        use results_interface, only : results_t
-        implicit none
-        character(len=*), intent(in) :: input_file
-        type(results_t) legacy_rocket
-      end function
-    end interface
-
-    open(newunit=file_unit, file="rocket.out", status="unknown", iostat=io_status, iomsg=error_message)
-    call assert(io_status == success, "main (opening rocket.out): io_status == success", diagnostic_data=error_message)
-    write(unit=file_unit, fmt=*) results_t(header, motor%derived_variables(history))
-    close(file_unit)
-
-    open(newunit=file_unit, file="legacy_rocket.out", status="unknown", iostat=io_status, iomsg=error_message)
-    call assert(io_status == success, "main (opening legacy_rocket.out): io_status == success", diagnostic_data=error_message)
-    write(unit=file_unit, fmt=*) legacy_rocket(input_file)
-    close(file_unit)
-  end subroutine
-
 end program

--- a/src/rocket/results_implementation.f90
+++ b/src/rocket/results_implementation.f90
@@ -37,4 +37,23 @@ contains
 
   end procedure
 
+  module procedure norm
+    norm_of_this = maxval(abs(this%body))
+  end procedure
+
+  module procedure subtract
+
+    type(results_t) local_difference
+
+    select type(rhs)
+      class is (results_t)
+        if (allocated(this%header) .and. allocated(rhs%header)) then
+          local_difference%header = "difference of " // this%header // "-" // rhs%header
+        end if
+        local_difference%body = this%body - rhs%body
+      class default
+        error stop "results_t%difference: unsupported rhs class"
+    end select
+    difference = local_difference
+  end procedure
 end submodule results_implementation

--- a/src/rocket/results_interface.f90
+++ b/src/rocket/results_interface.f90
@@ -1,17 +1,19 @@
 module results_interface
   use state_interface, only : state_t
+  use oracle_interface, only : oracle
   use kind_parameters, only : rkind
   implicit none
 
   private
 
-  type, public :: results_t
+  type, public, extends(oracle) :: results_t
     private
     character(len=:), allocatable :: header(:)
     real(rkind), allocatable :: body(:,:)
   contains
-    procedure, private :: write_formatted
-    generic :: write(formatted) => write_formatted
+    procedure :: write_formatted
+    procedure :: norm
+    procedure :: subtract
   end type
 
   interface results_t
@@ -43,6 +45,21 @@ module results_interface
       integer, intent(out) :: iostat
       character(len=*), intent(inout) :: iomsg
     end subroutine
+
+    pure module function norm(this) result(norm_of_this)
+      !! result is a norm of the array formed by concatenating the real components of this object
+      implicit none
+      class(results_t), intent(in) :: this
+      real(rkind) norm_of_this
+    end function
+
+    module function subtract(this, rhs) result(difference)
+      !! result has components corresponding to subtracting rhs's components fron this object's components
+      implicit none
+      class(results_t), intent(in) :: this
+      class(oracle), intent(in) :: rhs
+      class(oracle), allocatable :: difference
+    end function
 
   end interface
 

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -7,4 +7,8 @@ add_library(utilities
   universal_constants.f90
   array_functions_interface.f90
   array_functions_implementation.f90
+  oracle_interface.f90
+  oracle_implementation.f90
+  object_interface.f90
+  object_implementation.f90
 )

--- a/src/utilities/assertions_interface.F90
+++ b/src/utilities/assertions_interface.F90
@@ -5,7 +5,7 @@
 !     contract # NRC-HQ-60-17-C-0007
 !
 #ifndef USE_ASSERTIONS
-# define USE_ASSERTIONS .false.
+# define USE_ASSERTIONS .true.
 #endif
 module assertions_interface
   !! summary: Utility for runtime checking of logical assertions.

--- a/src/utilities/object_implementation.f90
+++ b/src/utilities/object_implementation.f90
@@ -1,0 +1,15 @@
+submodule(object_interface) object_implementation
+  !! Define the object type-bound procedures
+  implicit none
+
+contains
+
+    module procedure user_defined
+      me_defined = me%defined
+    end procedure
+
+    module procedure mark_as_defined
+      me%defined = .true.
+    end procedure
+
+end submodule object_implementation

--- a/src/utilities/object_interface.f90
+++ b/src/utilities/object_interface.f90
@@ -1,0 +1,57 @@
+module object_interface
+  !! Define the object type and type-bound procedure interface bodies
+  implicit none
+
+  private  !! default everything to private (information hiding)
+  public :: object  !! explicitly epxort only the type and  its
+                    !! public components and public type-bound procedures
+
+  type, abstract :: object
+    !! Encapsulate components and type-bound procedures that are
+    !! broadly (universally) useful across the entire project
+    private
+    logical :: defined=.false. !! default initialization
+  contains
+    procedure :: user_defined    ! get defined component
+    procedure :: mark_as_defined ! set defined component
+    procedure(write_formatted_interface), deferred :: write_formatted
+    generic :: write(formatted) => write_formatted
+  end type
+
+  abstract interface
+
+    subroutine write_formatted_interface(this, unit, iotype, vlist, iostat, iomsg)
+      import object
+      implicit none
+      class(object), intent(in) :: this
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: iotype
+      integer, intent(in) :: vlist(:)
+      integer, intent(out) :: iostat
+      character(len=*), intent(inout) :: iomsg
+    end subroutine
+
+  end interface
+
+  interface
+
+    pure module function user_defined(me) result(me_defined)
+      !! Report whether me has been defined
+
+      class(object), intent(in) :: me
+        !! "passed-object dummy argument"
+        !! Dynamic polymorphism: "class" facilitates passing in an argument
+        !! of type "object" or any type that extends the object type or
+        !! extends a type that extends the object type, ...
+      logical me_defined
+
+    end function
+
+    module subroutine mark_as_defined(me)
+      !! Mark the object as user-defined
+      class(object), intent(inout) :: me
+    end subroutine
+
+  end interface
+
+end module

--- a/src/utilities/oracle_implementation.f90
+++ b/src/utilities/oracle_implementation.f90
@@ -1,0 +1,15 @@
+submodule(oracle_interface) oracle_implementation
+  !! define procedures corresponding to the interface bodies in oracle_interface
+  implicit none
+
+contains
+
+  module procedure within_tolerance
+    class(oracle), allocatable :: error
+
+    error = this - reference
+    in_tolerance = (error%norm() <= tolerance)
+
+  end procedure
+
+end submodule oracle_implementation

--- a/src/utilities/oracle_interface.f90
+++ b/src/utilities/oracle_interface.f90
@@ -1,0 +1,54 @@
+module oracle_interface
+  !! verify actual output against expected
+  use object_interface, only : object
+  use kind_parameters, only : rkind
+  implicit none
+
+  private
+  public :: oracle
+
+  type, abstract, extends(object) :: oracle
+    !! define procedures for testing output values against expected values
+  contains
+    procedure(subtract_interface), deferred :: subtract
+    procedure(norm_interface), deferred :: norm
+    generic :: operator(-) => subtract
+    procedure :: within_tolerance
+  end type
+
+  abstract interface
+
+    function subtract_interface(this, rhs) result(difference)
+      !! result has components corresponding to subtracting rhs's components fron this object's components
+      import oracle
+      implicit none
+      class(oracle), intent(in) :: this, rhs
+      class(oracle), allocatable :: difference
+    end function
+
+    pure function norm_interface(this) result(norm_of_this)
+      !! result is a norm of the array formed by concatenating the real components of this object
+      import oracle, rkind
+      implicit none
+      class(oracle), intent(in) :: this
+      real(rkind) norm_of_this
+    end function
+
+  end interface
+
+  interface
+
+    module function within_tolerance(this, reference, tolerance) result(in_tolerance)
+      !! template method with true result iff the difference in state vectors (this - reference) has a norm within tolerance
+      !! (impure because of internal call to 'subtract' binding)
+      !! The existence of this procedure eliminates the need to rewrite similar code for every oracle child type.
+      implicit none
+      class(oracle), intent(in) :: this, reference
+      real(rkind), intent(in) :: tolerance
+      logical in_tolerance
+    end function
+
+  end interface
+
+
+end module


### PR DESCRIPTION
The modern code results are now checked against the legacy reference code results by computing the Eulerian distance between each output variable for the modern code and the nearest output value in `(t,v)` space, where `v` is any chosen output variable.  For each output value, a window 8 time steps wide is searched for the nearest legacy code output value. In regions wherein the variable varies rapidly over time, this result yields a much shorter distance than simply comparing the OO and legacy output variables at a single time.  The distance is normalized by the legacy code reference value so that the result is a percentage error estimate.

The results are also filtered, zeroing out percentage error in regions wherein the magnitude of the result is less than 1% of the peak value of the variable over the course of the simulation.  This eliminates noise in some of the smallest values, wherein the percentage error is large but the values themselves are inconsequential.