### PR TITLE
Verify the modern code against the legacy code (really)

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -31,7 +31,7 @@ program main
     end do
   end associate
 
-  call write_histories
+  call write_and_verify_results
   call graph_if_requested
 
   print *,"Test passed."
@@ -53,7 +53,7 @@ contains
     close(file_unit)
   end subroutine
 
-  subroutine write_histories
+  subroutine write_and_verify_results
     use results_interface, only : results_t
     character(len=*), parameter :: header(*) = &
         [character(len=len("temperature")) :: "time", "pressure", "temperature", "mdotos", "thrust", "volume"]
@@ -71,6 +71,12 @@ contains
       associate(legacy_results => legacy_rocket(input_file))
         call write_history(modern_results, "rocket.out")
         call write_history(legacy_results, "legacy_rocket.out")
+        block
+          use assertions_interface, only : assert
+          real(rkind), parameter :: tolerance = 0.01_rkind
+          call assert(modern_results%max_filtered_normalized_distance(legacy_results) < tolerance, &
+                     "modern_results%max_filtered_normalized_distance(legacy_results)")
+        end block
       end associate
     end associate
   end subroutine

--- a/src/rocket/results_interface.f90
+++ b/src/rocket/results_interface.f90
@@ -14,6 +14,8 @@ module results_interface
     procedure :: write_formatted
     procedure :: norm
     procedure :: subtract
+    procedure :: distance
+    procedure :: max_filtered_normalized_distance
   end type
 
   interface results_t
@@ -35,6 +37,13 @@ module results_interface
   end interface
 
   interface
+
+    pure module function  max_filtered_normalized_distance(this, rhs)
+      implicit none
+      class(results_t), intent(in) :: this
+      type(results_t), intent(in) :: rhs
+      real(rkind) max_filtered_normalized_distance
+    end function
 
     module subroutine write_formatted(this, unit, iotype, vlist, iostat, iomsg)
       implicit none
@@ -59,6 +68,14 @@ module results_interface
       class(results_t), intent(in) :: this
       class(oracle), intent(in) :: rhs
       class(oracle), allocatable :: difference
+    end function
+
+    pure module function distance(this, rhs)
+      !! result has components corresponding to subtracting rhs's components fron this object's components
+      implicit none
+      class(results_t), intent(in) :: this
+      type(results_t), intent(in) :: rhs
+      type(results_t) distance
     end function
 
   end interface


### PR DESCRIPTION
_This replaces PR #21, which was missing the commit that does everything described below_ 

Methodology:

* Compute the Eulerian distance between each modern-code output
  variable and the legacy-code output value that is closest in
  (t,v) space, where t is time and v is any chosen output variable.
* Search a window 8 time steps wide for the nearest legacy code
  output value. In regions wherein the variable is steeply sloped,
  this approach yields a much shorter distance than simply
  comparing the OO and legacy output variables at a single time.
* Normalize the Eulerian distance by the legacy code reference
  value so the result is a percentage-error estimate.
* Filtered the results by zeroing out the percentage error in
  regions wherein the magnitude of the legacy value is less than
  1% of the peak value of the variable over the course of the
  simulation. This eliminates noise in some of the smallest values,
  wherein the percentage error is large but the values themselves
  are inconsequential.